### PR TITLE
DE551: Add API_PROXY_MODULES variable to support module loading of API Proxy modules

### DIFF
--- a/hcsos.config
+++ b/hcsos.config
@@ -30,6 +30,7 @@ NODE_ENV=production
 #
 API_PROXY_HOST="$EXTERNAL_HOST"
 API_PROXY_PORT=8100
+API_PROXY_MODULES="--legacy proxy-agilityclassic"
 MARKETPLACE_PORT=8110
 # URL connecting API Proxy with BE
 BACKEND_URL="http://$BACKEND_HOST:$BACKEND_PORT/api"


### PR DESCRIPTION
* Add API_PROXY_MODULES variable to hcsos config file
* This will be used in the HCSOS_FE_START script